### PR TITLE
Fix Issue #10 - SQUUID generation multi-threading bug

### DIFF
--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -40,8 +40,7 @@
    
    See `generate-squuid` for more details."
   []
-  (let [ts #?(:clj (java.time.Instant/ofEpochMilli 123)
-              :cljs (t/current-time))]
+  (let [ts (t/current-time)]
     (swap! current-time-atom
            (fn [m]
              (if (t/before? (:timestamp m) ts)

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -28,6 +28,15 @@
          :base-uuid u/zero-uuid
          :squuid    u/zero-uuid}))
 
+(defn reset-all!
+  "Reset such that the starting timestamp and UUIDs are zeroed out. This
+   function is intended for use in development/testing."
+  []
+  (reset! current-time-atom
+          {:timestamp t/zero-time
+           :base-uuid u/zero-uuid
+           :squuid    u/zero-uuid}))
+
 (s/fdef generate-squuid*
   :args (s/cat)
   :ret (s/keys :req-un [::base-uuid ::timestamp ::squuid]))

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -40,19 +40,17 @@
    
    See `generate-squuid` for more details."
   []
-  (let [ts (t/current-time)
-        {curr-ts :timestamp} @current-time-atom]
-    (if (t/before? curr-ts ts)
-      ;; No timestamp clash - make new UUIDs
-      (swap! current-time-atom (fn [m]
-                                 (-> m
-                                     (assoc :timestamp ts)
-                                     (merge (u/make-squuid ts)))))
-      ;; Timestamp clash - increment UUIDs
-      (swap! current-time-atom (fn [m]
-                                 (-> m
-                                     (update :base-uuid u/inc-uuid)
-                                     (update :squuid u/inc-uuid)))))))
+  (let [ts #?(:clj (java.time.Instant/ofEpochMilli 123)
+              :cljs (t/current-time))]
+    (swap! current-time-atom
+           (fn [m]
+             (if (t/before? (:timestamp m) ts)
+               (-> m
+                   (assoc :timestamp ts)
+                   (merge (u/make-squuid ts)))
+               (-> m
+                   (update :base-uuid u/inc-uuid)
+                   (update :squuid u/inc-uuid)))))))
 
 (s/fdef generate-squuid
   :args (s/cat)

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -3,7 +3,8 @@
              [clojure.test :refer [deftest testing is]]
              [clojure.spec.test.alpha :refer [check instrument]]
              [com.yetanalytics.squuid :as squuid]
-             [com.yetanalytics.squuid.uuid :refer [compare-uuid]])]
+             [com.yetanalytics.squuid.uuid :refer [compare-uuid]]
+             [com.yetanalytics.squuid.time :as t])]
       :cljs [(:require
               [goog.math]
               [clojure.test.check]
@@ -41,4 +42,18 @@
     (let [squuid-seq  (repeatedly 1000 squuid/generate-squuid)
           squuid-seq' (sort (fn [u1 u2] (compare-uuid u1 u2)) squuid-seq)]
       (is (every? (fn [[u1 u2]] (zero? (compare-uuid u1 u2)))
-                  (map (fn [u1 u2] [u1 u2]) squuid-seq squuid-seq'))))))
+                  (map (fn [u1 u2] [u1 u2]) squuid-seq squuid-seq')))))
+  #?(:clj ; Is it even possible to test this in cljs?
+     (testing "squuid monotonicity (multi-threaded)"
+       (with-redefs [t/current-time #(java.time.Instant/ofEpochMilli 100)]
+         (is (->> (fn []
+                    (let [_       (squuid/reset-all!)
+                          [f1 f2] (pmap
+                                   (fn [f] (future (f)))
+                                   (repeat 2 squuid/generate-squuid))
+                          max-1   (last (sort [@f1 @f2]))
+                          new-u   (squuid/generate-squuid)
+                          max-2   (last (sort [max-1 new-u]))]
+                      [new-u max-2]))
+                  (repeatedly 30)
+                  (every? (partial apply =))))))))

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -43,7 +43,8 @@
           squuid-seq' (sort (fn [u1 u2] (compare-uuid u1 u2)) squuid-seq)]
       (is (every? (fn [[u1 u2]] (zero? (compare-uuid u1 u2)))
                   (map (fn [u1 u2] [u1 u2]) squuid-seq squuid-seq')))))
-  #?(:clj ; Is it even possible to test this in cljs?
+  ;; Test for: https://github.com/yetanalytics/colossal-squuid/issues/10
+  #?(:clj ; Rip cljs and its single thread.
      (testing "squuid monotonicity (multi-threaded)"
        (with-redefs [t/current-time #(java.time.Instant/ofEpochMilli 100)]
          (is (->> (fn []


### PR DESCRIPTION
Fix Issue #10 where SQUUID generation was not fully atomic. In other words, if SQUUIDs were generated from different threads on the same timestamp, instead of incrementing the random bits of the SQUUID, the random bits would be completely different, potentially violating the strict monotonicity property. In addition to fixing the bug itself, this PR adds tests based on the example given in #10.