### PR TITLE
Fix Clojars bug from v0.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean test-clj test-cljs ci
 
 clean:
-	rm -rf cljs-test-runner-out
+	rm -rf cljs-test-runner-out target
 
 test-clj:
 	clojure -M:test:runner-clj

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ci: test-clj test-cljs
 VERSION = LATEST
 
 build:
-	clojure -X:build jar :lib com.yetanalytics/colossal-squuid :version '"${VERSION}"'
+	clojure -X:build jar :lib com.yetanalytics/colossal-squuid :version '"${VERSION}"' :src-dirs '["src/main"]'
 
 deploy:
 	clojure -X:build deploy :lib com.yetanalytics/colossal-squuid :version '"${VERSION}"'

--- a/README.md
+++ b/README.md
@@ -10,15 +10,21 @@ A SQUUID is a Universally Unique Identifier, or UUID, whose value increases stri
 
 ## Installation
 
+If using deps.edn add the following line to your `:deps` alias:
 ```clojure
-{com.yetanalytics/colossal-squuid {:mvn/version "0.1.2"}}
+com.yetanalytics/colossal-squuid {:mvn/version "0.1.3"}
+```
+
+If using Leiningen/Boot add the following dep:
+```clojure
+[com.yetanalytics/colossal-squuid "0.1.3"]
 ```
 
 **Note:** By default colossal-squuid will bring in the Clojure and ClojureScript libraries as transitive dependencies. If you wish to exclude these from your project (e.g. because it is clj or cljs-only), you can use the `:exclusions` keyword:
 ```clojure
-{com.yetanalytics/colossal-squuid {:mvn/version "0.1.2"
-                                   :exclusions [org.clojure/clojure
-                                                org.clojure/clojurescript]}}
+com.yetanalytics/colossal-squuid {:mvn/version "0.1.3"
+                                  :exclusions [org.clojure/clojure
+                                                org.clojure/clojurescript]}
 ```
 
 ## Implementation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SQUUID is a Universally Unique Identifier, or UUID, whose value increases stri
 
 ## Installation
 
-If using deps.edn add the following line to your `:deps` alias:
+If using deps.edn add the following line to your `:deps` map:
 ```clojure
 com.yetanalytics/colossal-squuid {:mvn/version "0.1.3"}
 ```


### PR DESCRIPTION
v0.1.2 had a bug where the incorrect source dirs were being compiled into the JAR. This fixes it by adding the `:src-dirs` args to the Makefile target