### PR TITLE
Add a `uuid->time` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Four functions are provided in the `com.yetanalytics.squuid` namespace:
 - `time->uuid` takes a timestamp and creates a SQUUID with a fixed (not random)  base UUID portion.
 - `uuid->time` takes a SQUUID and returns its corresponding timestamp.
 
+**Note:** `generate-squuid*` and `uuid->time` return timestamps as `java.time.Instant` instances in Clojure, `#inst` in ClojureScript.
+
 ```clojure
 (generate-squuid)
 ;; => #uuid "017de28f-5801-8c62-9ce9-cef70883794a"

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ See the [Clojars page](https://clojars.org/com.yetanalytics/colossal-squuid) for
 
 ## API
 
-Three functions are provided in the `com.yetanalytics.squuid` namespace:
+Four functions are provided in the `com.yetanalytics.squuid` namespace:
 - `generate-squuid` generates a SQUUID based off of a random base UUID and a timestamp representing the current time.
 - `generate-squuid*`, which returns a map containing the base UUID, the timestamp, and the SQUUID.
-- `time->uuid*` takes a timestamp and creates a SQUUID with a fixed (not random)  base UUID portion.
+- `time->uuid` takes a timestamp and creates a SQUUID with a fixed (not random)  base UUID portion.
+- `uuid->time` takes a SQUUID and returns its corresponding timestamp.
 
 ```clojure
 (generate-squuid)
@@ -39,6 +40,9 @@ Three functions are provided in the `com.yetanalytics.squuid` namespace:
 
 (time->uuid #inst "2021-12-22T14:33:04.769000000-00:00")
 ;; => #uuid "017de28f-5801-8fff-8fff-ffffffffffff"
+
+(uuid->time #uuid "017de28f-5801-8fff-8fff-ffffffffffff")
+;; => #inst "2021-12-22T14:33:04.769000000-00:00"
 ```
 
 ## Implementation

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -1,8 +1,8 @@
 (ns com.yetanalytics.squuid
-  #?(:clj (:import [java.time Instant]))
   (:require [clojure.spec.alpha :as s]
             [com.yetanalytics.squuid.uuid :as u]
-            [com.yetanalytics.squuid.time :as t]))
+            [com.yetanalytics.squuid.time :as t])
+  #?(:clj (:import [java.time Instant])))
 
 ;; This library generates sequential UUIDs, or SQUUIDs, based on the draft RFC
 ;; for v8 UUIDS:
@@ -101,8 +101,9 @@
   :ret ::timestamp)
 
 (defn uuid->time
-  "Convert a previously generated UUID to its corresponding timestamp."
+  "Convert a previously generated `uuid` to its corresponding timestamp."
   [uuid]
+  (assert (uuid? uuid))
   #?(:clj
      (-> (.getMostSignificantBits uuid)
          (bit-shift-right 16)

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -1,4 +1,5 @@
 (ns com.yetanalytics.squuid
+  #?(:clj (:import [java.time Instant]))
   (:require [clojure.spec.alpha :as s]
             [com.yetanalytics.squuid.uuid :as u]
             [com.yetanalytics.squuid.time :as t]))
@@ -94,3 +95,20 @@
   [ts]
   (:squuid
    (u/make-squuid ts #uuid "00000000-0000-4FFF-8FFF-FFFFFFFFFFFF")))
+
+(s/fdef uuid->time
+  :args (s/cat :uuid ::squuid)
+  :ret ::timestamp)
+
+(defn uuid->time
+  "Convert a previously generated UUID to its corresponding timestamp."
+  [uuid]
+  #?(:clj
+     (-> (.getMostSignificantBits uuid)
+         (bit-shift-right 16)
+         (Instant/ofEpochMilli))
+     :cljs
+     (let [s (str uuid)]
+       (-> (str (subs s 0 8) (subs s 9 13))
+           (js/parseInt 16)
+           (js/Date.)))))

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -1,8 +1,7 @@
 (ns com.yetanalytics.squuid
   (:require [clojure.spec.alpha :as s]
             [com.yetanalytics.squuid.uuid :as u]
-            [com.yetanalytics.squuid.time :as t])
-  #?(:clj (:import [java.time Instant])))
+            [com.yetanalytics.squuid.time :as t]))
 
 ;; This library generates sequential UUIDs, or SQUUIDs, based on the draft RFC
 ;; for v8 UUIDS:
@@ -102,15 +101,15 @@
   :ret ::timestamp)
 
 (defn uuid->time
-  "Convert a previously generated `uuid` to its corresponding timestamp."
+  "Convert a previously generated `uuid` to its corresponding timestamp.
+   Returns a java.time.Instant object in Clojure, #inst in ClojureScript."
   [uuid]
   (assert (uuid? uuid))
   #?(:clj
-     (-> (.getMostSignificantBits uuid)
-         (bit-shift-right 16)
-         (Instant/ofEpochMilli))
+     (-> uuid
+         (u/extract-ts-bytes)
+         (t/ms->Instant))
      :cljs
-     (let [s (str uuid)]
-       (-> (str (subs s 0 8) (subs s 9 13))
-           (js/parseInt 16)
-           (js/Date.)))))
+     (-> uuid
+         (u/extract-ts-bytes)
+         (js/Date.))))

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.squuid
   (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.squuid.uuid :as u]
             [com.yetanalytics.squuid.time :as t]))
 
@@ -18,8 +19,11 @@
 (s/def ::base-uuid uuid?)
 (s/def ::squuid uuid?)
 (s/def ::timestamp
-  #?(:clj (partial instance? java.time.Instant)
-     :cljs (partial instance? js/Date)))
+  #?(:clj (s/with-gen (partial instance? java.time.Instant)
+            #(sgen/fmap (fn [ts] (t/ms->Instant (inst-ms ts)))
+                        (s/gen inst?)))
+     :cljs (s/with-gen (partial instance? js/Date)
+             #(s/gen inst?))))
 
 ;; The atom is private so that only generate-squuid(*) can mutate it.
 ;; Note that merging Instant/EPOCH with v0 UUID returns the v0 UUID again.

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -93,6 +93,7 @@
    the timestamp, while the lower 80 bits are fixed at
    `8FFF-8FFF-FFFFFFFFFFFF`."
   [ts]
+  (assert (inst? ts))
   (:squuid
    (u/make-squuid ts #uuid "00000000-0000-4FFF-8FFF-FFFFFFFFFFFF")))
 

--- a/src/main/com/yetanalytics/squuid.cljc
+++ b/src/main/com/yetanalytics/squuid.cljc
@@ -1,8 +1,8 @@
 (ns com.yetanalytics.squuid
   (:require [clojure.spec.alpha :as s]
-            [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.squuid.uuid :as u]
-            [com.yetanalytics.squuid.time :as t]))
+            [com.yetanalytics.squuid.time :as t]
+            #?(:clj [clojure.spec.gen.alpha :as sgen])))
 
 ;; This library generates sequential UUIDs, or SQUUIDs, based on the draft RFC
 ;; for v8 UUIDS:

--- a/src/main/com/yetanalytics/squuid/time.cljc
+++ b/src/main/com/yetanalytics/squuid/time.cljc
@@ -29,3 +29,10 @@
   "Does `time1` occur strictly before `time2`?"
   #?(:clj ([^Instant time1 ^Instant time2] (.isBefore time1 time2))
      :cljs ([time1 time2] (< time1 time2))))
+
+#?(:clj
+   (defn ms->Instant
+     "Convenience function returning a java.time.Instant object 
+      given `ms` from the beginning of the UNIX epoch."
+     [ms]
+     (Instant/ofEpochMilli ms)))

--- a/src/main/com/yetanalytics/squuid/uuid.cljc
+++ b/src/main/com/yetanalytics/squuid/uuid.cljc
@@ -59,6 +59,7 @@
          (> u1 u2) 1))))
 
 (defn extract-ts-bytes
+  "Extracts the first 48 bits of a SQUUID corresponding to a timestamp."
   [^UUID uuid]
   #?(:clj
      (-> (.getMostSignificantBits uuid)

--- a/src/main/com/yetanalytics/squuid/uuid.cljc
+++ b/src/main/com/yetanalytics/squuid/uuid.cljc
@@ -58,6 +58,16 @@
          (= u1 u2) 0
          (> u1 u2) 1))))
 
+(defn extract-ts-bytes
+  [^UUID uuid]
+  #?(:clj
+     (-> (.getMostSignificantBits uuid)
+         (bit-shift-right 16))
+     :cljs
+     (let [s (str uuid)]
+       (-> (str (subs s 0 8) (subs s 9 13)))
+       (js/parseInt 16))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Private helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/com/yetanalytics/squuid/uuid.cljc
+++ b/src/main/com/yetanalytics/squuid/uuid.cljc
@@ -65,8 +65,8 @@
          (bit-shift-right 16))
      :cljs
      (let [s (str uuid)]
-       (-> (str (subs s 0 8) (subs s 9 13)))
-       (js/parseInt 16))))
+       (-> (str (subs s 0 8) (subs s 9 13))
+           (js/parseInt 16)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Private helpers

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -72,8 +72,8 @@
        (is (thrown? Exception
                     (squuid/time->uuid "2021-12-27T16:16:37.269Z")))
        :cljs
-       (is (thrown-with-msg? js/Error #"Assert failed"
-                             (squuid/time->uuid "2021-12-27T16:16:37.269Z"))))))
+       (is (thrown? js/Error
+                    (squuid/time->uuid "2021-12-27T16:16:37.269Z"))))))
 
 (deftest uuid->time-test
   (testing "confirm it matches with generate-squuid*"
@@ -89,12 +89,12 @@
              inst #inst "2021-12-27T16:16:37.269Z"
              java-inst (t/ms->Instant (inst-ms inst))]
          (is (= java-inst (squuid/uuid->time uuid))))
-       (:cljs
-        (let [uuid #uuid "017dfcad-ef95-8fff-8fff-ffffffffffff"
-              inst #inst "2021-12-27T16:16:37.269Z"]
-          (is (= inst (squuid/uuid->time uuid)))))))
+       :cljs
+       (let [uuid #uuid "017dfcad-ef95-8fff-8fff-ffffffffffff"
+             inst #inst "2021-12-27T16:16:37.269Z"]
+         (is (= inst (squuid/uuid->time uuid))))))
   (testing "input must be an uuid"
     #?(:clj
        (is (thrown? Exception (squuid/uuid->time "string uuid")))
        :cljs
-       (is (thrown-with-msg? js/Error #"Assert failed" (squuid/uuid->time "string uuid"))))))
+       (is (thrown? js/Error (squuid/uuid->time "string uuid"))))))

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -67,7 +67,14 @@
   (testing "Matching #inst and #uuid"
     (let [uuid #uuid "017dfcad-ef95-8fff-8fff-ffffffffffff"
           inst #inst "2021-12-27T16:16:37.269Z"]
-      (is (= uuid (squuid/time->uuid inst))))))
+      (is (= uuid (squuid/time->uuid inst)))))
+  (testing "input must be #inst"
+    #?(:clj
+       (is (thrown? Exception
+                    (squuid/time->uuid "2021-12-27T16:16:37.269Z")))
+       :cljs
+       (is (thrown-with-msg? js/Error #"Assert failed"
+                             (squuid/time->uuid "2021-12-27T16:16:37.269Z"))))))
 
 (deftest uuid->time-test
   (testing "confirm it matches with generate-squuid*"

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -4,8 +4,7 @@
              [clojure.spec.test.alpha :refer [check instrument]]
              [com.yetanalytics.squuid :as squuid]
              [com.yetanalytics.squuid.uuid :refer [compare-uuid]]
-             [com.yetanalytics.squuid.time :as t])
-            (:import [java.time Instant])]
+             [com.yetanalytics.squuid.time :as t])]
       :cljs [(:require
               [goog.math]
               [clojure.test.check]
@@ -88,7 +87,7 @@
     #?(:clj
        (let [uuid #uuid "017dfcad-ef95-8fff-8fff-ffffffffffff"
              inst #inst "2021-12-27T16:16:37.269Z"
-             java-inst (Instant/ofEpochMilli (inst-ms inst))]
+             java-inst (t/ms->Instant (inst-ms inst))]
          (is (= java-inst (squuid/uuid->time uuid))))
        (:cljs
         (let [uuid #uuid "017dfcad-ef95-8fff-8fff-ffffffffffff"

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -20,11 +20,13 @@
   (testing "squuid gentests"
     (instrument [`squuid/generate-squuid*
                  `squuid/generate-squuid
-                 `squuid/time->uuid])
+                 `squuid/time->uuid
+                 `squuid/uuid->time])
     (is (every? #(-> % :clojure.spec.test.check/ret :pass?)
                 (check [`squuid/generate-squuid*
                         `squuid/generate-squuid
-                        `squuid/time->uuid])))))
+                        `squuid/time->uuid
+                        `squuid/uuid->time])))))
 
 (deftest squuid-monotone-test
   (testing "squuid monotonicity"
@@ -58,3 +60,9 @@
                       [new-u max-2]))
                   (repeatedly 30)
                   (every? (partial apply =))))))))
+
+(deftest uuid->time-test
+  (testing
+   (is (let [id (squuid/generate-squuid*)
+             time (squuid/uuid->time (:squuid id))]
+         (= (:timestamp id) time)))))

--- a/src/test/com/yetanalytics/squuid_test.cljc
+++ b/src/test/com/yetanalytics/squuid_test.cljc
@@ -89,4 +89,6 @@
           (is (= inst (squuid/uuid->time uuid)))))))
   (testing "input must be an uuid"
     #?(:clj
-       (is (thrown? Exception (squuid/uuid->time "string uuid"))))))
+       (is (thrown? Exception (squuid/uuid->time "string uuid")))
+       :cljs
+       (is (thrown-with-msg? js/Error #"Assert failed" (squuid/uuid->time "string uuid"))))))


### PR DESCRIPTION
Let me know what you think.

Perhaps I should've defined it in `time.cljc`, then created a wrapper in `squuid.cljc`, to forego the `:import`?